### PR TITLE
do not retrieve object for empty values

### DIFF
--- a/filer/fields/file.py
+++ b/filer/fields/file.py
@@ -74,13 +74,16 @@ class AdminFileWidget(ForeignKeyRawIdWidget):
         return '&nbsp;<strong>%s</strong>' % truncate_words(obj, 14)
 
     def obj_for_value(self, value):
-        try:
-            key = self.rel.get_related_field().name
-            if LTE_DJANGO_1_8:
-                obj = self.rel.to._default_manager.get(**{key: value})
-            else:
-                obj = self.rel.model._default_manager.get(**{key: value})
-        except ObjectDoesNotExist:
+        if value:
+            try:
+                key = self.rel.get_related_field().name
+                if LTE_DJANGO_1_8:
+                    obj = self.rel.to._default_manager.get(**{key: value})
+                else:
+                    obj = self.rel.model._default_manager.get(**{key: value})
+            except ObjectDoesNotExist:
+                obj = None
+        else:
             obj = None
         return obj
 


### PR DESCRIPTION
fix for issue:
filer/fields/file.py raises error when fields are empty #1125